### PR TITLE
Made CodeMarkup public

### DIFF
--- a/src/RoslynTestKit/CodeMarkup.cs
+++ b/src/RoslynTestKit/CodeMarkup.cs
@@ -4,7 +4,7 @@ using RoslynTestKit.Utils;
 
 namespace RoslynTestKit
 {
-    class CodeMarkup
+    public class CodeMarkup
     {
         public CodeMarkup(string markup)
         {


### PR DESCRIPTION
Hey.

First of all, thank you for the library, it is really helpful :+1: 

I'd like to suggest making CodeMarkup class public. I'm testing code refactoring which operates on multiple files - it should be triggered from one file, and then it adds some code into another file. In order to test it I had to copy CodeMarkup class to my project. Then I was able to use it to mark one source file, used this CodeMarkup to create CodeRefactoringContext, and then use Verify.CodeAction to test it.